### PR TITLE
Pass unevaluated file pattern to prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "eject": "react-scripts-ts eject",
     "lint": "tslint --project .",
     "lintfix": "tslint --fix --project .",
-    "format": "prettier src/**/*.{ts,tsx} --write",
-    "testformat": "prettier src/**/*.{ts,tsx} --list-different"
+    "format": "prettier 'src/**/*.{ts,tsx}' --write",
+    "testformat": "prettier 'src/**/*.{ts,tsx}' --list-different"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Somehow the pattern doesn't include `src/index.tsx` on my machine.